### PR TITLE
Внедрение options pattern

### DIFF
--- a/Interpreter/CommandLineSettings.cs
+++ b/Interpreter/CommandLineSettings.cs
@@ -10,7 +10,7 @@ namespace Interpreter
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "PropertyCanBeMadeInitOnly.Global")]
-    public class Options
+    public class CommandLineSettings
     {
         [Value(0, MetaName = "InputFilePath", Required = true, HelpText = "Path to input file")]
         public string InputFilePath { get; set; }
@@ -24,9 +24,9 @@ namespace Interpreter
             get
             {
                 yield return new Example("Simple interpretation call", 
-                    new Options { InputFilePath = "file.js" });
+                    new CommandLineSettings { InputFilePath = "file.js" });
                 yield return new Example("Request dump",
-                    new Options { InputFilePath = "file.js", Dump = true });
+                    new CommandLineSettings { InputFilePath = "file.js", Dump = true });
             }
         }
 

--- a/Interpreter/Services/Executor/IExecutor.cs
+++ b/Interpreter/Services/Executor/IExecutor.cs
@@ -2,6 +2,6 @@ namespace Interpreter.Services.Executor
 {
     public interface IExecutor
     {
-        void Execute(Options options);
+        void Execute();
     }
 }

--- a/Interpreter/Services/Executor/Impl/Executor.cs
+++ b/Interpreter/Services/Executor/Impl/Executor.cs
@@ -9,6 +9,7 @@ using Interpreter.Lib.Semantic.Analysis;
 using Interpreter.Lib.Semantic.Exceptions;
 using Interpreter.Lib.VM;
 using Interpreter.Services.Providers;
+using Microsoft.Extensions.Options;
 
 namespace Interpreter.Services.Executor.Impl
 {
@@ -16,19 +17,21 @@ namespace Interpreter.Services.Executor.Impl
     {
         private readonly ILexerProvider _lexerProvider;
         private readonly IParserProvider _parserProvider;
+        private readonly CommandLineSettings _commandLineSettings;
 
-        public Executor(ILexerProvider lexerProvider, IParserProvider parserProvider)
+        public Executor(ILexerProvider lexerProvider, IParserProvider parserProvider, IOptions<CommandLineSettings> optionsProvider)
         {
             _lexerProvider = lexerProvider;
             _parserProvider = parserProvider;
+            _commandLineSettings = optionsProvider.Value;
         }
 
-        public void Execute(Options options)
+        public void Execute()
         {
             try
             {
                 var lexer = _lexerProvider
-                    .CreateLexer(options.CreateLexerQuery());
+                    .CreateLexer(_commandLineSettings.CreateLexerQuery());
 
                 var parser = _parserProvider
                     .CreateParser(lexer);
@@ -52,9 +55,9 @@ namespace Interpreter.Services.Executor.Impl
                 var vm = new VirtualMachine(cfg);
                 vm.Run();
                 
-                if (options.Dump)
+                if (_commandLineSettings.Dump)
                 {
-                    var fileName = options.GetInputFileName();
+                    var fileName = _commandLineSettings.GetInputFileName();
                     File.WriteAllLines(
                         $"{fileName}.tac",
                         instructions.OrderBy(i => i).Select(i => i.ToString())


### PR DESCRIPTION
Смотри ссылку https://docs.microsoft.com/en-us/dotnet/core/extensions/options
На текущий момент опции передавались как параметр метода, но видение архитектуры предполагало их распространение чуть ли не по всем контрактам в текущей конфигурации. Этот bad design practice надо исправить