### PR TITLE
Исправление бага по разрешению ссылок

### DIFF
--- a/Interpreter.Lib/Semantic/Types/ArrayType.cs
+++ b/Interpreter.Lib/Semantic/Types/ArrayType.cs
@@ -2,28 +2,11 @@ namespace Interpreter.Lib.Semantic.Types
 {
     public class ArrayType : Type
     {
-        public Type Type { get; private set; }
+        public Type Type { get; set; }
 
         public ArrayType(Type type) : base($"{type}[]")
         {
             Type = type;
-        }
-
-        public override void ResolveReference(string reference, Type toAssign)
-        {
-            if (Type == reference)
-            {
-                Type = toAssign;
-            }
-            else switch (Type)
-            {
-                case ObjectType objectType:
-                    objectType.ResolveSelfReferences(reference);
-                    break;
-                default:
-                    Type.ResolveReference(reference, toAssign);
-                    break;
-            }
         }
 
         public override bool Equals(object obj)

--- a/Interpreter.Lib/Semantic/Types/ArrayType.cs
+++ b/Interpreter.Lib/Semantic/Types/ArrayType.cs
@@ -1,3 +1,6 @@
+using Interpreter.Lib.Semantic.Types.Visitors;
+using Visitor.NET.Lib.Core;
+
 namespace Interpreter.Lib.Semantic.Types
 {
     public class ArrayType : Type
@@ -8,6 +11,9 @@ namespace Interpreter.Lib.Semantic.Types
         {
             Type = type;
         }
+        
+        public override Unit Accept(ReferenceResolver visitor) =>
+            visitor.Visit(this);
 
         public override bool Equals(object obj)
         {

--- a/Interpreter.Lib/Semantic/Types/FunctionType.cs
+++ b/Interpreter.Lib/Semantic/Types/FunctionType.cs
@@ -17,40 +17,6 @@ namespace Interpreter.Lib.Semantic.Types
             Arguments = new List<Type>(arguments);
         }
 
-        public override void ResolveReference(string reference, Type toAssign)
-        {
-            if (ReturnType.ToString() == reference)
-            {
-                ReturnType = toAssign;
-            } 
-            else switch (ReturnType)
-            {
-                case ObjectType objectType:
-                    objectType.ResolveSelfReferences(reference);
-                    break;
-                default:
-                    ReturnType.ResolveReference(reference, toAssign);
-                    break;
-            }
-
-            for (var i = 0; i < Arguments.Count; i++)
-            {
-                if (Arguments[i].ToString() == reference)
-                {
-                    Arguments[i] = toAssign;
-                }
-                else switch (Arguments[i])
-                {
-                    case ObjectType objectType:
-                        objectType.ResolveSelfReferences(reference);
-                        break;
-                    default:
-                        Arguments[i].ResolveReference(reference, toAssign);
-                        break;
-                }
-            }
-        }
-
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(this, obj)) return true;

--- a/Interpreter.Lib/Semantic/Types/FunctionType.cs
+++ b/Interpreter.Lib/Semantic/Types/FunctionType.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Interpreter.Lib.Semantic.Types.Visitors;
+using Visitor.NET.Lib.Core;
 
 namespace Interpreter.Lib.Semantic.Types
 {
     public class FunctionType : Type
     {
-        public Type ReturnType { get; private set; }
+        public Type ReturnType { get; set; }
         
         public List<Type> Arguments { get; }
 
@@ -17,6 +19,9 @@ namespace Interpreter.Lib.Semantic.Types
             Arguments = new List<Type>(arguments);
         }
 
+        public override Unit Accept(ReferenceResolver visitor) =>
+            visitor.Visit(this);
+        
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(this, obj)) return true;

--- a/Interpreter.Lib/Semantic/Types/NullableType.cs
+++ b/Interpreter.Lib/Semantic/Types/NullableType.cs
@@ -1,3 +1,6 @@
+using Interpreter.Lib.Semantic.Types.Visitors;
+using Visitor.NET.Lib.Core;
+
 namespace Interpreter.Lib.Semantic.Types
 {
     public class NullableType : Type
@@ -12,6 +15,9 @@ namespace Interpreter.Lib.Semantic.Types
         protected NullableType()
         {
         }
+        
+        public override Unit Accept(ReferenceResolver visitor) =>
+            visitor.Visit(this);
 
         public override bool Equals(object obj)
         {

--- a/Interpreter.Lib/Semantic/Types/NullableType.cs
+++ b/Interpreter.Lib/Semantic/Types/NullableType.cs
@@ -2,7 +2,7 @@ namespace Interpreter.Lib.Semantic.Types
 {
     public class NullableType : Type
     {
-        public Type Type { get; private set; }
+        public Type Type { get; set; }
         
         public NullableType(Type type) : base($"{type}?")
         {
@@ -11,23 +11,6 @@ namespace Interpreter.Lib.Semantic.Types
 
         protected NullableType()
         {
-        }
-        
-        public override void ResolveReference(string reference, Type toAssign)
-        {
-            if (Type == reference)
-            {
-                Type = toAssign;
-            }
-            else switch (Type)
-            {
-                case ObjectType objectType:
-                    objectType.ResolveSelfReferences(reference);
-                    break;
-                default:
-                    Type.ResolveReference(reference, toAssign);
-                    break;
-            }
         }
 
         public override bool Equals(object obj)

--- a/Interpreter.Lib/Semantic/Types/ObjectType.cs
+++ b/Interpreter.Lib/Semantic/Types/ObjectType.cs
@@ -25,8 +25,7 @@ namespace Interpreter.Lib.Semantic.Types
 
         public Type this[string id]
         {
-            get =>
-                _properties.ContainsKey(id)
+            get => _properties.ContainsKey(id)
                     ? _properties[id]
                     : null;
             set => _properties[id] = value;
@@ -37,12 +36,9 @@ namespace Interpreter.Lib.Semantic.Types
         public void ResolveSelfReferences(string self) =>
             new ReferenceResolver(this, self)
                 .Visit(this);
-        
-        public override Unit Accept(ReferenceResolver visitor)
-        {
+
+        public override Unit Accept(ReferenceResolver visitor) =>
             visitor.Visit(this);
-            return default;
-        }
 
         public override bool Equals(object obj)
         {

--- a/Interpreter.Lib/Semantic/Types/ObjectType.cs
+++ b/Interpreter.Lib/Semantic/Types/ObjectType.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Interpreter.Lib.Semantic.Types.Visitors;
+using Visitor.NET.Lib.Core;
 
 namespace Interpreter.Lib.Semantic.Types
 {
@@ -21,36 +23,27 @@ namespace Interpreter.Lib.Semantic.Types
             _serializer = new ObjectTypeToStringSerializer(this);
         }
 
-        public Type this[string id] => _properties.ContainsKey(id)
-            ? _properties[id]
-            : null;
+        public Type this[string id]
+        {
+            get =>
+                _properties.ContainsKey(id)
+                    ? _properties[id]
+                    : null;
+            set => _properties[id] = value;
+        }
 
         public IEnumerable<string> Keys => _properties.Keys;
 
-        public void ResolveSelfReferences(string self)
-        {
-            foreach (var (key, property) in _properties)
-            {
-                if (property == self)
-                {
-                    _properties[key] = this;
-                } 
-                else switch (property)
-                {
-                    case ObjectType objectType:
-                        if (objectType != this)
-                        {
-                            objectType.ResolveSelfReferences(self);
-                        }
-
-                        break;
-                    default:
-                        property.ResolveReference(self, this);
-                        break;
-                }
-            }
-        }
+        public void ResolveSelfReferences(string self) =>
+            new ReferenceResolver(this, self)
+                .Visit(this);
         
+        public override Unit Accept(ReferenceResolver visitor)
+        {
+            visitor.Visit(this);
+            return default;
+        }
+
         public override bool Equals(object obj)
         {
             if (obj is ObjectType that)

--- a/Interpreter.Lib/Semantic/Types/Type.cs
+++ b/Interpreter.Lib/Semantic/Types/Type.cs
@@ -1,6 +1,9 @@
+using Interpreter.Lib.Semantic.Types.Visitors;
+using Visitor.NET.Lib.Core;
+
 namespace Interpreter.Lib.Semantic.Types
 {
-    public class Type
+    public class Type : IVisitable<ReferenceResolver, Unit>
     {
         private readonly string _name;
 
@@ -10,9 +13,8 @@ namespace Interpreter.Lib.Semantic.Types
 
         public Type(string name) => _name = name;
 
-        public virtual void ResolveReference(string reference, Type toAssign)
-        {
-        }
+        public virtual Unit Accept(ReferenceResolver visitor)
+            => visitor.Visit(this);
 
         public override bool Equals(object obj)
         {

--- a/Interpreter.Lib/Semantic/Types/Visitors/ReferenceResolver.cs
+++ b/Interpreter.Lib/Semantic/Types/Visitors/ReferenceResolver.cs
@@ -41,7 +41,21 @@ namespace Interpreter.Lib.Semantic.Types.Visitors
 
         public Unit Visit(FunctionType visitable)
         {
-            throw new System.NotImplementedException();
+            if (visitable.ReturnType == _refId)
+                visitable.ReturnType = _reference;
+            else
+                visitable.ReturnType.Accept(this);
+
+            for (var i = 0; i < visitable.Arguments.Count; i++)
+            {
+                var argType = visitable.Arguments[i];
+                if (argType == _refId)
+                    visitable.Arguments[i] = _reference;
+                else
+                    argType.Accept(this);
+            }
+
+            return default;
         }
 
         public Unit Visit(NullableType visitable)

--- a/Interpreter.Lib/Semantic/Types/Visitors/ReferenceResolver.cs
+++ b/Interpreter.Lib/Semantic/Types/Visitors/ReferenceResolver.cs
@@ -1,0 +1,33 @@
+using Visitor.NET.Lib.Core;
+
+namespace Interpreter.Lib.Semantic.Types.Visitors
+{
+    public class ReferenceResolver :
+        IVisitor<Type, Unit>,
+        IVisitor<ObjectType, Unit>
+    {
+        private readonly ObjectType _reference;
+        private readonly string _refId;
+
+        public ReferenceResolver(ObjectType reference, string refId)
+        {
+            _reference = reference;
+            _refId = refId;
+        }
+        
+        public Unit Visit(ObjectType visitable)
+        {
+            foreach (var key in visitable.Keys)
+            {
+                if (_refId == visitable[key])
+                    visitable[key] = _reference;
+                else
+                    visitable[key].Accept(this);
+            }
+
+            return default;
+        }
+
+        public Unit Visit(Type visitable) => default;
+    }
+}

--- a/Interpreter.Lib/Semantic/Types/Visitors/ReferenceResolver.cs
+++ b/Interpreter.Lib/Semantic/Types/Visitors/ReferenceResolver.cs
@@ -4,6 +4,9 @@ namespace Interpreter.Lib.Semantic.Types.Visitors
 {
     public class ReferenceResolver :
         IVisitor<Type, Unit>,
+        IVisitor<ArrayType, Unit>,
+        IVisitor<FunctionType, Unit>,
+        IVisitor<NullableType, Unit>, 
         IVisitor<ObjectType, Unit>
     {
         private readonly ObjectType _reference;
@@ -18,16 +21,36 @@ namespace Interpreter.Lib.Semantic.Types.Visitors
         public Unit Visit(ObjectType visitable)
         {
             foreach (var key in visitable.Keys)
-            {
                 if (_refId == visitable[key])
                     visitable[key] = _reference;
                 else
                     visitable[key].Accept(this);
-            }
-
             return default;
         }
 
         public Unit Visit(Type visitable) => default;
+        
+        public Unit Visit(ArrayType visitable)
+        {
+            if (visitable.Type == _refId)
+                visitable.Type = _reference;
+            else
+                visitable.Type.Accept(this);
+            return default;
+        }
+
+        public Unit Visit(FunctionType visitable)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Unit Visit(NullableType visitable)
+        {
+            if (visitable.Type == _refId)
+                visitable.Type = _reference;
+            else
+                visitable.Type.Accept(this);
+            return default;
+        }
     }
 }

--- a/Interpreter.Tests/Unit/TypeTests.cs
+++ b/Interpreter.Tests/Unit/TypeTests.cs
@@ -97,12 +97,15 @@ namespace Interpreter.Tests.Unit
                 new List<PropertyType>
                 {
                     new("data", number),
-                    new("next", new Type("self"))
+                    new("wrapped", new ObjectType(new List<PropertyType>
+                    {
+                        new("next", new Type("self"))
+                    }))
                 }
             );
             linkedListType.ResolveSelfReferences("self");
             var wrapper = new ObjectType(new List<PropertyType> {new("data", number)});
-            Assert.True(linkedListType.Equals(linkedListType["next"]));
+            Assert.True(linkedListType.Equals(((ObjectType)linkedListType["wrapped"])["next"]));
             Assert.False(linkedListType.Equals(wrapper));
             Assert.Contains("@this", linkedListType.ToString());
         }


### PR DESCRIPTION
В рамках работы над исправлением бага с сериализацией объектного типа был найден баг с разрешением ссылок.
Ссылки неправильно разрешаются, что приводит к возникновению бесконечных рекурсий