### PR TITLE
Создание детализированного отчёта о покрытии кода

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore -c Release -v n
       - name: Test
-        run: dotnet test -c Release --no-build -v n /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --filter="Category=Unit"
+        run: |
+          dotnet test -c Release --no-build -v n /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --filter="Category=Unit"
+          mkdir ejss-coverage-report
       - name: Code Coverage Summary Report For Merge Request
         if: github.event_name == 'pull_request'
         uses: 5monkeys/cobertura-action@master
@@ -54,4 +56,13 @@ jobs:
           hide_branch_rate: true
           hide_complexity: true
           thresholds: '80 100'
- 
+      - name: ReportGenerator
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.1.10
+        with:
+          reports: './Interpreter.Tests/coverage.cobertura.xml' 
+          targetdir: './ejss-coverage-report' 
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v2.2.3
+        with:
+          name: CoverageReport   
+          path: ejss-coverage-report

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Test
         run: |
           dotnet test -c Release --no-build -v n /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura --filter="Category=Unit"
-          mkdir ejss-coverage-report
+          mkdir coverage-report
       - name: Code Coverage Summary Report For Merge Request
         if: github.event_name == 'pull_request'
         uses: 5monkeys/cobertura-action@master
@@ -60,9 +60,10 @@ jobs:
         uses: danielpalme/ReportGenerator-GitHub-Action@5.1.10
         with:
           reports: './Interpreter.Tests/coverage.cobertura.xml' 
-          targetdir: './ejss-coverage-report' 
+          targetdir: './coverage-report' 
       - name: Upload coverage report artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v2.2.3
         with:
           name: CoverageReport   
-          path: ejss-coverage-report
+          path: coverage-report


### PR DESCRIPTION
Текущий markddown комментарий в coverage этапе пайпа не отражает всю ситуацию с покрытием кода: нет деталей покрытия условий, скрываются часть файлов, где-то не указываются номера строк.

Для решения проблемы в пайп внедряется этот инструмент:
https://github.com/danielpalme/ReportGenerator
