### PR TITLE
Внедрение пакета System.IO.Abstractions

### DIFF
--- a/Interpreter.Tests/MockExtensions.cs
+++ b/Interpreter.Tests/MockExtensions.cs
@@ -1,5 +1,6 @@
 using Interpreter.Lib.BackEnd;
 using Interpreter.Lib.BackEnd.Instructions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Interpreter.Tests
@@ -13,5 +14,9 @@ namespace Interpreter.Tests
             halt.Setup(x => x.End()).Returns(true);
             return halt;
         }
+
+        public static IOptions<CommandLineSettings> ToOptions
+            (this Mock<CommandLineSettings> commandLineSettings) =>
+            Options.Create(commandLineSettings.Object);
     }
 }

--- a/Interpreter.Tests/Unit/Infrastructure/ExecutorTests.cs
+++ b/Interpreter.Tests/Unit/Infrastructure/ExecutorTests.cs
@@ -8,7 +8,6 @@ using Interpreter.Lib.IR.Ast;
 using Interpreter.Services.Executor.Impl;
 using Interpreter.Services.Parsing;
 using Interpreter.Tests.Stubs;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -38,7 +37,7 @@ namespace Interpreter.Tests.Unit.Infrastructure
             _parsingService.Setup(x => x.Parse(It.IsAny<string>()))
                 .Returns(ast.Object);
 
-            var executor = new Executor(_parsingService.Object, Options.Create(_settings.Object));
+            var executor = new Executor(_parsingService.Object, _settings.ToOptions());
             Assert.Null(Record.Exception(() => executor.Execute()));
         }
 
@@ -52,7 +51,7 @@ namespace Interpreter.Tests.Unit.Infrastructure
             _parsingService.Setup(x => x.Parse(It.IsAny<string>()))
                 .Returns(ast.Object);
 
-            var executor = new Executor(_parsingService.Object, Options.Create(_settings.Object));
+            var executor = new Executor(_parsingService.Object, _settings.ToOptions());
             Assert.Null(Record.Exception(() => executor.Execute()));
         }
         
@@ -62,7 +61,7 @@ namespace Interpreter.Tests.Unit.Infrastructure
             _parsingService.Setup(x => x.Parse(It.IsAny<string>()))
                 .Throws<LexerException>();
 
-            var executor = new Executor(_parsingService.Object, Options.Create(_settings.Object));
+            var executor = new Executor(_parsingService.Object, _settings.ToOptions());
             Assert.Null(Record.Exception(() => executor.Execute()));
         }
         
@@ -72,7 +71,7 @@ namespace Interpreter.Tests.Unit.Infrastructure
             _parsingService.Setup(x => x.Parse(It.IsAny<string>()))
                 .Throws<ParserException>();
 
-            var executor = new Executor(_parsingService.Object, Options.Create(_settings.Object));
+            var executor = new Executor(_parsingService.Object, _settings.ToOptions());
             Assert.Null(Record.Exception(() => executor.Execute()));
         }
         
@@ -90,7 +89,7 @@ namespace Interpreter.Tests.Unit.Infrastructure
             _parsingService.Setup(x => x.Parse(It.IsAny<string>()))
                 .Returns(ast.Object);
 
-            var executor = new Executor(_parsingService.Object, Options.Create(_settings.Object));
+            var executor = new Executor(_parsingService.Object, _settings.ToOptions());
             Assert.Null(Record.Exception(() => executor.Execute()));
         }
     }

--- a/Interpreter.Tests/Unit/Infrastructure/LoggingEntitiesTests.cs
+++ b/Interpreter.Tests/Unit/Infrastructure/LoggingEntitiesTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using Interpreter.Lib.BackEnd.Instructions;
+using Interpreter.Lib.FrontEnd.GetTokens;
+using Interpreter.Lib.FrontEnd.GetTokens.Data;
+using Interpreter.Lib.FrontEnd.TopDownParse;
+using Interpreter.Lib.IR.Ast;
+using Interpreter.Services.Providers.Impl.LexerProvider;
+using Interpreter.Services.Providers.Impl.ParserProvider;
+using Moq;
+using Xunit;
+
+namespace Interpreter.Tests.Unit.Infrastructure
+{
+    public class LoggingEntitiesTests
+    {
+        private readonly Mock<IFile> _file;
+        private readonly Mock<IFileSystem> _fileSystem;
+
+        public LoggingEntitiesTests()
+        {
+            _file = new Mock<IFile>();
+
+            _fileSystem = new Mock<IFileSystem>();
+            _fileSystem.Setup(x => x.File)
+                .Returns(_file.Object);
+        }
+
+        [Fact]
+        public void CorrectFileNameProducedByLexerTest()
+        {
+            var lexer = new Mock<ILexer>();
+            lexer.Setup(x => x.GetTokens(It.IsAny<string>()))
+                .Returns(new List<Token>());
+            lexer.Setup(x => x.ToString())
+                .Returns("lexer");
+
+            _file.Setup(x => x.WriteAllText(
+                It.IsAny<string>(), It.IsAny<string>()
+            )).Verifiable();
+
+            var loggingLexer = new LoggingLexer(lexer.Object, "file", _fileSystem.Object);
+            loggingLexer.GetTokens("");
+
+            _file.Verify(x => x.WriteAllText(
+                It.Is<string>(p => p == "file.tokens"), It.Is<string>(c => c == "lexer")
+            ), Times.Once());
+        }
+        
+        [Fact]
+        public void CorrectTreeWrittenAndLoggingTreeProducedTest()
+        {
+            var ast = new Mock<IAbstractSyntaxTree>();
+            ast.Setup(x => x.ToString())
+                .Returns("digraph ast { }");
+            
+            var parser = new Mock<IParser>();
+            parser.Setup(x => x.TopDownParse(It.IsAny<string>()))
+                .Returns(ast.Object);
+
+            _file.Setup(x => x.WriteAllText(
+                It.IsAny<string>(), It.IsAny<string>()
+            )).Verifiable();
+
+            var loggingParser = new LoggingParser(parser.Object, "file", _fileSystem.Object);
+            var parsed = loggingParser.TopDownParse("");
+
+            _file.Verify(x => x.WriteAllText(
+                It.Is<string>(p => p == "ast.dot"),
+                It.Is<string>(c => c == "digraph ast { }")
+            ), Times.Once());
+            Assert.IsType<LoggingAbstractSyntaxTree>(parsed);
+        }
+
+        [Fact]
+        public void CorrectFileNameProducedByTreeTest()
+        {
+            var ast = new Mock<IAbstractSyntaxTree>();
+            ast.Setup(x => x.GetInstructions())
+                .Returns(new List<Instruction> { new Halt(0) });
+
+            _file.Setup(x => x.WriteAllLines(
+                It.IsAny<string>(), It.IsAny<IEnumerable<string>>()
+            )).Verifiable();
+
+            var loggingTree = new LoggingAbstractSyntaxTree(ast.Object, "file", _fileSystem.Object);
+            loggingTree.GetInstructions();
+
+            _file.Verify(x => x.WriteAllLines(
+                It.Is<string>(p => p == "file.tac"),
+                It.Is<IEnumerable<string>>(c => c.SequenceEqual(new[] { "0: End" }))
+            ), Times.Once());
+        }
+    }
+}

--- a/Interpreter/Interpreter.csproj
+++ b/Interpreter/Interpreter.csproj
@@ -15,6 +15,7 @@
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+      <PackageReference Include="System.IO.Abstractions" Version="17.2.1" />
     </ItemGroup>
 
 </Project>

--- a/Interpreter/Services/Providers/Impl/LexerProvider/LexerProvider.cs
+++ b/Interpreter/Services/Providers/Impl/LexerProvider/LexerProvider.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using AutoMapper;
 using Interpreter.Lib.FrontEnd.GetTokens;
 using Interpreter.Lib.FrontEnd.GetTokens.Data;
@@ -23,7 +24,7 @@ namespace Interpreter.Services.Providers.Impl.LexerProvider
             var domain = _mapper.Map<StructureModel, Structure>(_settings.StructureModel);
             var lexer = new Lexer(domain);
             return _settings.Dump
-                ? new LoggingLexer(lexer, _settings.GetInputFileName())
+                ? new LoggingLexer(lexer, _settings.GetInputFileName(), new FileSystem())
                 : lexer;
         }
     }

--- a/Interpreter/Services/Providers/Impl/LexerProvider/LoggingLexer.cs
+++ b/Interpreter/Services/Providers/Impl/LexerProvider/LoggingLexer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.IO.Abstractions;
 using Interpreter.Lib.FrontEnd.GetTokens;
 using Interpreter.Lib.FrontEnd.GetTokens.Data;

--- a/Interpreter/Services/Providers/Impl/LexerProvider/LoggingLexer.cs
+++ b/Interpreter/Services/Providers/Impl/LexerProvider/LoggingLexer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using Interpreter.Lib.FrontEnd.GetTokens;
 using Interpreter.Lib.FrontEnd.GetTokens.Data;
 
@@ -9,11 +10,13 @@ namespace Interpreter.Services.Providers.Impl.LexerProvider
     {
         private readonly ILexer _lexer;
         private readonly string _fileName;
+        private readonly IFileSystem _fileSystem;
 
-        public LoggingLexer(ILexer lexer, string fileName)
+        public LoggingLexer(ILexer lexer, string fileName, IFileSystem fileSystem)
         {
             _lexer = lexer;
             _fileName = fileName;
+            _fileSystem = fileSystem;
         }
 
         public Structure Structure => _lexer.Structure;
@@ -21,7 +24,7 @@ namespace Interpreter.Services.Providers.Impl.LexerProvider
         public List<Token> GetTokens(string text)
         {
             var tokens = _lexer.GetTokens(text);
-            File.WriteAllText(
+            _fileSystem.File.WriteAllText(
                 $"{_fileName}.tokens",
                 _lexer.ToString()
             );

--- a/Interpreter/Services/Providers/Impl/ParserProvider/LoggingAbstractSyntaxTree.cs
+++ b/Interpreter/Services/Providers/Impl/ParserProvider/LoggingAbstractSyntaxTree.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using Interpreter.Lib.BackEnd.Instructions;

--- a/Interpreter/Services/Providers/Impl/ParserProvider/LoggingAbstractSyntaxTree.cs
+++ b/Interpreter/Services/Providers/Impl/ParserProvider/LoggingAbstractSyntaxTree.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using Interpreter.Lib.BackEnd.Instructions;
 using Interpreter.Lib.IR.Ast;
@@ -10,17 +11,19 @@ namespace Interpreter.Services.Providers.Impl.ParserProvider
     {
         private readonly IAbstractSyntaxTree _ast;
         private readonly string _fileName;
+        private readonly IFileSystem _fileSystem;
 
-        public LoggingAbstractSyntaxTree(IAbstractSyntaxTree ast, string fileName)
+        public LoggingAbstractSyntaxTree(IAbstractSyntaxTree ast, string fileName, IFileSystem fileSystem)
         {
             _ast = ast;
             _fileName = fileName;
+            _fileSystem = fileSystem;
         }
     
         public List<Instruction> GetInstructions()
         {
             var instructions = _ast.GetInstructions();
-            File.WriteAllLines(
+            _fileSystem.File.WriteAllLines(
                 $"{_fileName}.tac",
                 instructions.OrderBy(i => i).Select(i => i.ToString())
             );

--- a/Interpreter/Services/Providers/Impl/ParserProvider/LoggingParser.cs
+++ b/Interpreter/Services/Providers/Impl/ParserProvider/LoggingParser.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.IO.Abstractions;
 using Interpreter.Lib.FrontEnd.TopDownParse;
 using Interpreter.Lib.IR.Ast;
 
@@ -8,19 +9,21 @@ namespace Interpreter.Services.Providers.Impl.ParserProvider
     {
         private readonly IParser _parser;
         private readonly string _fileName;
+        private readonly IFileSystem _fileSystem;
 
-        public LoggingParser(IParser parser, string fileName)
+        public LoggingParser(IParser parser, string fileName, IFileSystem fileSystem)
         {
             _parser = parser;
             _fileName = fileName;
+            _fileSystem = fileSystem;
         }
     
         public IAbstractSyntaxTree TopDownParse(string text)
         {
             var ast = _parser.TopDownParse(text);
             var astDot = ast.ToString();
-            File.WriteAllText("ast.dot", astDot);
-            return new LoggingAbstractSyntaxTree(ast, _fileName);
+            _fileSystem.File.WriteAllText("ast.dot", astDot);
+            return new LoggingAbstractSyntaxTree(ast, _fileName, _fileSystem);
         }
     }
 }

--- a/Interpreter/Services/Providers/Impl/ParserProvider/LoggingParser.cs
+++ b/Interpreter/Services/Providers/Impl/ParserProvider/LoggingParser.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.IO.Abstractions;
 using Interpreter.Lib.FrontEnd.TopDownParse;
 using Interpreter.Lib.IR.Ast;

--- a/Interpreter/Services/Providers/Impl/ParserProvider/ParserProvider.cs
+++ b/Interpreter/Services/Providers/Impl/ParserProvider/ParserProvider.cs
@@ -1,3 +1,4 @@
+using System.IO.Abstractions;
 using Interpreter.Lib.FrontEnd.TopDownParse;
 using Parser = Interpreter.Lib.FrontEnd.TopDownParse.Impl.Parser;
 using Microsoft.Extensions.Options;
@@ -20,7 +21,7 @@ namespace Interpreter.Services.Providers.Impl.ParserProvider
             var lexer = _lexerProvider.CreateLexer();
             var parser = new Parser(lexer);
             return _settings.Dump
-                ? new LoggingParser(parser, _settings.GetInputFileName())
+                ? new LoggingParser(parser, _settings.GetInputFileName(), new FileSystem())
                 : parser;
         }
     }


### PR DESCRIPTION
На данный момент невозможно протестировать поведение логгируемых сущностей. Они производят запись в файл, используя статические методы из `System.IO`.

[**System.IO.Abstractions**](https://github.com/TestableIO/System.IO.Abstractions) позволит отслеживать этот процесс во время unit-тестирования.